### PR TITLE
Fix Word.compareTo ordering

### DIFF
--- a/src/main/java/com/sentence/dictionary/domain/Word.java
+++ b/src/main/java/com/sentence/dictionary/domain/Word.java
@@ -30,18 +30,9 @@ public class Word extends BaseEntity implements Comparable<Word>{
 
     @Override
     public int compareTo(Word word) {
-        int response=0;
-        switch (word.getWordCategory()) {
-            case NOUN:
-                response = 1;
-                break;
-            case VERB:
-                response = 2;
-                break;
-            case ADJECTIVE:
-                response=3;
-                break;
+        if (word == null || this.wordCategory == null || word.getWordCategory() == null) {
+            return 0;
         }
-        return response;
+        return Integer.compare(this.wordCategory.ordinal(), word.getWordCategory().ordinal());
     }
 }


### PR DESCRIPTION
## Summary
- fix `Word.compareTo` to compare enumerated category ordering

## Testing
- `./mvnw -q -DskipTests package` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_686e3ea45f38832b96a6d224d8149c31